### PR TITLE
Création d'un profile d'exécution pour la CI spécifique.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build
-      run: make build
+      run: make ci

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ clean: 						## Cleanup project files (basically run `mvn clean`)
 build: 						## Build project with running all tests (basically run `mvn package`)
 	mvn package -B
 
+ci:
+	mvn package -B -P ci
+
 install-only-bench-tools: 	## Install locally all tools lib necessary to run maven perf tests.
 	mvn install -pl bench-tools-maven -am -B
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,6 @@
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
 
-    <modules>
-        <module>bench-tools</module>
-        <module>bench-tools-maven</module>
-        <module>maven-perf</module>
-    </modules>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -64,4 +58,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>bench-tools</module>
+                <module>bench-tools-maven</module>
+                <module>maven-perf</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>ci</id>
+            <modules>
+                <module>bench-tools</module>
+                <module>bench-tools-maven</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
En mode CI, on ne check que les modules permettant la construction des modules bench tools afin d'éviter de lancer également les tests de bench prenant un temps extrêmement long lorsqu'ils sont tous lancés (plus d'une heure) ce qui bloque Github Actions empêchant d'avoir l'accès aux logs et nous faisant penser que le build ne fonctionne pas alors qu'il est justement en train de tourner.